### PR TITLE
Adding support for M5Core2 v1.1 in "no comments" .ino

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 # M5Stack_Core2_ScreenBrightness
 The Core2 screen brightness is capable of a much larger range of intensities than the standard functions use.
 
+## Core2 (previous version):
+
 This Arduino .ino sketch file contains a useful function: **core2Brightness()**                   
 Normally the brightness can be set from **8 through 20**. (2.5 volts to 2.8 volts)                         
 This function not enly extends the range of brightness values that can be used from **1 through 36**, but it also turns the LED off at value 0.                      
@@ -30,3 +32,23 @@ This gives an extra 16 brightness levels ABOVE the Core2's standard brightness s
 The .ino sketch shows these settings in action, use the touchscreen to control it:
 
 ![image](https://user-images.githubusercontent.com/1586332/128866190-4e3f69bd-8aa7-40ec-92f7-ed0894d540bc.png)
+
+## Core2 (v1.1):
+
+Added in the code "no comments" support for version 1.1 of M5Core2 power management, where it offers values:
+
+**void core2Brightness(uint8_t lvl, bool overdrive = false)**
+The "lvl" parameter:
+0: Backlight physically off.
+10: The standard brightness set by the Core2 1.1 library. (3.3 volts)
+All other values are clamped between 0 and 10.
+
+The "overdrive" parameter:
+This gives an extra 2 brightness levels ABOVE the Core2's v1.1 standard brightness setting.
+0: Backlight physically off.
+10: The max brightness set by the Core2 1.1 library. (3.3 volts)
+12: Full brightness the screen LED can do. (3.5 volts)
+
+**🔴WARNING!🔴**
+Setting "turbo" to true, and brightness over 10 CAN damage your display.
+Therefore there's an optional safety "overdrive" flag if you want to drive the LCD backlight higher than the recommended voltage of 3.3 (up to 3.5) that needs to be set to **true**. If it's false, or omitted from the function call, it's impossible to go over the safe 3.3 volts.

--- a/ScreenBrightnessNoComments/ScreenBrightnessNoComments.ino
+++ b/ScreenBrightnessNoComments/ScreenBrightnessNoComments.ino
@@ -1,39 +1,63 @@
-
 #include <M5Core2.h>
 
+enum pmic_t { pmic_unknown = 0, pmic_axp192, pmic_axp2101 };
+pmic_t _pmic;
 
 void core2Brightness(uint8_t lvl, bool overdrive = false) {
-  int v = lvl * 25 + 2300;
-  if (v < 2300) v = 2300;
-  if (overdrive) {
-    if (v > 3200) v = 3200;
+  if (_pmic == pmic_axp2101) {
+    int v = lvl * 100 + 2300;
+    if (v < 2300) v = 2300;
+    if (overdrive) {
+      if (v > 3500) v = 3500;
+    } else {
+      if (v > 3300) v = 3300;
+    }
+    if (v == 2300) {
+      M5.Axp.axp2101.set_bldo1_on_off(false);
+      return;
+    } else {
+      M5.Axp.axp2101.set_bldo1_on_off(true);
+    }
+      M5.Axp.axp2101.set_lcd_back_light_voltage(v);
+  } else if (_pmic == pmic_axp192) {
+    int v = lvl * 25 + 2300;
+    if (v < 2300) v = 2300;
+    if (overdrive) {
+      if (v > 3200) v = 3200;
+    } else {
+      if (v > 2800) v = 2800;
+    }
+    if (v == 2300) {
+      M5.Axp.SetDCDC3(false);
+      return;
+    } else {
+      M5.Axp.SetDCDC3(true);
+    }
+    M5.Axp.SetDCVoltage(2, v);
   } else {
-    if (v > 2800) v = 2800;
-  }
-  if (v == 2300) {
-    M5.Axp.SetDCDC3(false);
     return;
-  } else {
-    M5.Axp.SetDCDC3(true);
   }
-  M5.Axp.SetDCVoltage(2, v);
 }
 
 void setup() {
   M5.begin();
   M5.Lcd.fillScreen(WHITE);
+  uint8_t val = Read8bit(0x03);
+  if (val == 0x03) _pmic = pmic_axp192;
+  else if (val == 0x4A) _pmic = pmic_axp2101;
+  else _pmic = pmic_unknown;
 }
 
 void loop() {
+  uint8_t maxSafe = _pmic == pmic_axp2101 ? 10 : _pmic == pmic_axp192 ? 20 : 0;
 
-  for (uint8_t b = 0; b <= 20; b++) {
+  for (uint8_t b = 0; b <= maxSafe; b++) {
     core2Brightness(b);
     delay(50);
   }
-  
-  for (uint8_t b = 19; b > 0; b--) {
+
+  for (uint8_t b = maxSafe - 1; b > 0; b--) {
     core2Brightness(b);
     delay(50);
   }
-  
 }


### PR DESCRIPTION
# Adding support for M5Core2 v1.1 in "no comments" .ino

The M5Core2 has received a new version called 1.1, which uses a different power management from the previous version. The previous version uses the AXP192, while version 1.1 uses the AXP2101 + INA3221 (see https://docs.m5stack.com/en/core/Core2%20v1.1), where the ID is how the library distinguishes the versions. Therefore, I made a modification in the code "no comments" to distinguish the version used and apply it to the "core2Brightness" function.

In version 1.1 (with the libraries updated to their latest version), the "ScreenBreath" function handles brightness changes well, but provides values from 0 to 100, where 0 means the display is not completely turned off and 100 is not the maximum the display can handle (it's just the recommended maximum value), and certain value changes don't reflect any brightness change. In my tests, I noticed that the "set_lcd_back_light_voltage" function of the AXP2101 only offers noticeable display changes with every hundredth change in millivolts, meaning if you change from 2400 to 2499, there won't be any changes, but from 2499 to 2500, you'll notice a perceptible change. So, I adapted the code to iterate by 100, having a total of 10 safety values and 12 total values (considering turbo).

## Added functionalities:

- Recognition of the power management used (whether AXP192 or AXP2101) and adaptation of the code to support these managements (I based this on the AXP.cpp from the M5Core2 library to make this distinction).
- New brightness ranges according to the version of M5Core2 used. Values beyond the minimum (0 = display off), beyond the recommended maximum (11 or 12, where the same library of the same .cpp module says that the maximum voltage value of BLDO1 is 3500mV, but the recommended value is 3300mV), and intervals that truly reflect brightness change were also added (every 100mV).

## Tests conducted:

- Tested on M5Core2 v1.1 with the latest version of the Board (esp32 2.0.14 by Espressif Systems) and libraries (M5Core2 0.1.9 by M5Stack). I couldn't test it on the previous version of M5Core2 because I don't have the device in question (if you can test it, I will be very grateful).

**Notes**: Feel free to implement the same adaptation for the GUI version of the program (ScreenBrightness\ScreenBrightness.ino), but the "no comments" version that I am changing is enough to apply to different projects.